### PR TITLE
Fixes bug in FAQ page

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -15,12 +15,12 @@ permalink: /faq/
   {% for category in site.data.faq %}
     <div class="card card-block mt-2">
       <h2 class="text-xs-center">{{ category[0] | capitalize }}</h2>
-      <div id="accordion-{{category[0]}}" role="tablist" aria-multiselectable="true">
+      <div id="accordion-{{category[0] | replace: ' ',''}}" role="tablist" aria-multiselectable="true">
         {% for question in category[1] %}
         <div class="card">
           <div class="card-header" role="tab" id="heading-{{question[0]}}">
             <h5 class="mb-0">
-              <a data-toggle="collapse" data-parent="#accordion-{{category[0]}}" href="#collapse-{{question[0]}}" aria-expanded="true" aria-controls="collapse-{{question[0]}}">
+              <a data-toggle="collapse" data-parent="#accordion-{{category[0] | replace: ' ',''}}" href="#collapse-{{question[0]}}" aria-expanded="true" aria-controls="collapse-{{question[0]}}">
                 {{question[1].question}}
               </a>
             </h5>


### PR DESCRIPTION
Hi Matt,

I found a bug in the FAQ page and fixed it.  

## Bug
The issue was that when using the data toggle, it will not work with spaces (i.e. Keynote address and Conference day) and if you open a question in those 2 categories it will not close the first one in that category when you click a different one in the same category.  Hope my description makes sense.

## Fix
I fixed it by deleting the spaces using the 'remove filer' by going `{{category[0] | replace: ' ',''}}`.  It fixes it...

Michael 